### PR TITLE
Prevent scrolling stats menu and zooming tree simultaneously

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -166,6 +166,11 @@ export class App {
             }
         }, true)
 
+        // don't propagate scroll event inside stats menu to not zoom in tree at the same time
+        document.getElementById('skillTreeStats')!.addEventListener('wheel', event => {
+            event.stopPropagation();
+        }, true)
+
         document.addEventListener('keydown', function (event: KeyboardEvent) {
 
             // This also prevents browser zoom


### PR DESCRIPTION
Scrolling inside the stats menu is also zooming the tree due to the event propagating into the outer elements.
I simply added an event listener to the stats element to stop the propagation.